### PR TITLE
fix:修复图片和双链有时会冲突的问题

### DIFF
--- a/link-processor.ts
+++ b/link-processor.ts
@@ -90,31 +90,42 @@ export class LinkProcessor {
      */
     extractWikiLinks(content: string): WikiLinkInfo[] {
         const wikiLinks: WikiLinkInfo[] = [];
-        
-        // 匹配Obsidian双链格式: [[文档标题]] 或 [[文档标题|显示文本]]
-        const wikiLinkRegex = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
-        
+
+        // 图片扩展名列表
+        const imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp', '.svg'];
+
+        // 匹配所有 [[...]] 格式（包括 ![[...]]）
+        const allLinksRegex = /(!?)\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
+
         let match;
-        while ((match = wikiLinkRegex.exec(content)) !== null) {
-            if (!match[1]) continue; // 跳过无效匹配
-            
-            const title = match[1].trim(); // 文档标题
-            const originalText = match[0]; // 完整的双链语法
-            const position = match.index; // 在内容中的位置
-            
+        while ((match = allLinksRegex.exec(content)) !== null) {
+            const hasExclamation = match[1] === '!'; // 是否有 ! 前缀
+            const title = match[2]?.trim(); // 文档标题或文件名
+            if (!title) continue;
+
+            // 检查是否是图片文件
+            const isImage = imageExtensions.some(ext => title.toLowerCase().endsWith(ext));
+
+            // 跳过图片
+            if (isImage) {
+                continue;
+            }
+
+            // 对于 ![[文档名]]，originalText 需要包含 !，以便后续完整替换
+            const originalText = match[0]; // 完整匹配（包括可能的 !）
+            const position = match.index;
+
             // 查找对应的文件
             const file = this.findFileByTitle(title);
-            
+
             wikiLinks.push({
                 originalText,
                 title,
                 position,
-                ...(file && { file }) // 只有当file存在时才添加file属性
+                ...(file && { file })
             });
-            
-
         }
-        
+
         return wikiLinks;
     }
 

--- a/main.js
+++ b/main.js
@@ -3421,13 +3421,20 @@ var _LinkProcessor = class {
    * @returns 双链信息数组
    */
   extractWikiLinks(content) {
+    var _a;
     const wikiLinks = [];
-    const wikiLinkRegex = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
+    const imageExtensions = [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".svg"];
+    const allLinksRegex = /(!?)\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
     let match;
-    while ((match = wikiLinkRegex.exec(content)) !== null) {
-      if (!match[1])
+    while ((match = allLinksRegex.exec(content)) !== null) {
+      const hasExclamation = match[1] === "!";
+      const title = (_a = match[2]) == null ? void 0 : _a.trim();
+      if (!title)
         continue;
-      const title = match[1].trim();
+      const isImage = imageExtensions.some((ext) => title.toLowerCase().endsWith(ext));
+      if (isImage) {
+        continue;
+      }
       const originalText = match[0];
       const position = match.index;
       const file = this.findFileByTitle(title);
@@ -3436,7 +3443,6 @@ var _LinkProcessor = class {
         title,
         position,
         ...file && { file }
-        // 只有当file存在时才添加file属性
       });
     }
     return wikiLinks;


### PR DESCRIPTION
## 修改内容

通过判断引用目标的图片扩展名，区分 Obsidian 中的文档引用和图片引用，避免将图片或非文档嵌入语法错误地按文档链接处理。


主要修复了以下两个问题：

## Bug 1: 文档嵌入语法被错误转换为 Markdown 图片语法

### 问题场景

Obsidian 原始内容：

```markdown
这是一段文字 ![[我的文档]] 继续文字
```

旧版本处理流程：

1. 正则 `/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g` 只匹配 `[[...]]`，不会捕获前面的 `!`
2. 提取到 `title = "我的文档"`，`originalText = "[[我的文档]]"`
3. 上传后替换：`[[我的文档]]` → `[我的文档](飞书URL)`
4. 最终结果变成：`![[我的文档]]` → `![我的文档](飞书URL)`

### 问题影响

`![文档](URL)` 会被识别为 Markdown 图片语法，导致飞书尝试将文档链接当作图片加载，最终显示“图片加载失败”。

<img width="1286" height="966" alt="image" src="https://github.com/user-attachments/assets/55542f06-1a4b-4630-a81b-a1f44d4901d3" />

---

## Bug 2: 图片引用因模糊匹配触发无关文档误上传

### 问题场景

文件库结构：

```text
图.md       ← 文档
架构图.png  ← 图片
```

Obsidian 原始内容：

```markdown
查看截图 ![[架构图.png]] 了解详情
```

旧版本处理流程：

1. 正则匹配到 `[[架构图.png]]`
2. 提取到 `title = "架构图.png"`
3. 没有检查文件扩展名，继续按文档处理
4. 调用 `findFileByTitle("架构图.png")`
5. 精确匹配失败，因为不存在名为 `架构图.png` 的文档
6. 路径匹配失败
7. 进入模糊匹配逻辑：

```ts
// 双向包含匹配
return baseName.includes(titleLower) || titleLower.includes(baseName);
```

8. `"架构图.png".includes("图")` 返回 `true`
9. 错误匹配到 `图.md`
10. 最终导致 `图.md` 被误上传，而真正的图片 `架构图.png` 没有被正确处理

## 修复方式

在处理 WikiLink 前增加图片扩展名判断：

* 如果引用目标是图片文件，则不再按文档链接上传处理
* 避免图片引用触发文档的模糊匹配逻辑
* 避免 `![[文档]]` 被错误转换成 Markdown 图片语法

## 测试场景

已验证以下场景：

* `![[我的文档]]` 不会被错误转换为 `![我的文档](飞书URL)`
* `![[架构图.png]]` 不会触发文档模糊匹配
* 当同时存在 `图.md` 和 `架构图.png` 时，不会错误匹配并上传 `图.md`
